### PR TITLE
Resolved `string refs issues` for newer version compatibility and some code cleanup

### DIFF
--- a/src/blocks/embed.js
+++ b/src/blocks/embed.js
@@ -7,7 +7,7 @@ var Types = require('./embeds');
 
 function getDomain(link) {
   var a = url.parse(link);
-  return a.hostname;
+  return a.hostname === 'youtu.be' ? 'youtube.com' : a.hostname;
 }
 
 let Embed = {
@@ -38,6 +38,7 @@ class BlockEmbed extends React.Component {
       url: '',
       className: ''
     };
+    this.urlInput = null;
 
     this.getClassName = this.getClassName.bind(this);
     this.checkUrls = this.checkUrls.bind(this);
@@ -74,11 +75,11 @@ class BlockEmbed extends React.Component {
         }
       }
       alert('This URL is not supported.');
-      this.refs.input.value = '';
+      this.urlInput.value = '';
     } else {
       if(!isProp) {
         alert("Enter a valid url");
-        this.refs.input.value = '';
+        this.urlInput.value = '';
       }
     }
     UrlRegex.lastIndex = 0;
@@ -92,7 +93,7 @@ class BlockEmbed extends React.Component {
 
   componentDidMount() {
     if(this.props.content.url === '') {
-      this.refs.input.focus();
+      this.urlInput.focus();
     }
     this.checkUrls(this.props.content.url, true);
   }
@@ -193,7 +194,7 @@ class BlockEmbed extends React.Component {
           onDrop={this.onDrop}>
           <p>Drop links here or paste below</p>
           <input
-            ref="input"
+            ref={(node) => {this.urlInput=node}}
             type="text"
             placeholder="Enter URL and press enter"
             onKeyUp={this.handleUrl} />

--- a/src/blocks/embeds/facebook.js
+++ b/src/blocks/embeds/facebook.js
@@ -68,7 +68,7 @@ class Facebook extends BaseEmbed {
       if(!this.state.preview) {
         return (
           <div className="katap-embed katap-facebook">
-            <p>Facebook - <a href={this.props.url} target="_blank">{this.props.url}</a></p>
+            <p>Facebook - <a href={this.props.url} target="_blank" rel="noopener noreferrer">{this.props.url}</a></p>
             <button className="katap-show-preview-btn" onClick={this.showPreview}>Preview</button>
           </div>
         );

--- a/src/blocks/embeds/index.js
+++ b/src/blocks/embeds/index.js
@@ -4,7 +4,7 @@ import Vine from './vine';
 import Instagram from './instagram';
 import Facebook from './facebook';
 
-module.exports = {
+export default {
   youtube: Youtube,
   instagram: Instagram,
   vimeo: Vimeo,

--- a/src/blocks/embeds/instagram.js
+++ b/src/blocks/embeds/instagram.js
@@ -7,7 +7,7 @@ class Instagram extends BaseEmbed {
       if(!this.state.preview) {
         return (
           <div className="katap-embed katap-instagram">
-            <p>Instagram - <a href={this.props.url} target="_blank">{this.props.url}</a></p>
+            <p>Instagram - <a href={this.props.url} target="_blank" rel="noopener noreferrer">{this.props.url}</a></p>
             <button className="katap-show-preview-btn" onClick={this.showPreview}>Preview</button>
           </div>
         );
@@ -16,6 +16,7 @@ class Instagram extends BaseEmbed {
         <div className="katap-embed katap-instagram">
           <iframe
             src={'//instagram.com/p/'+this.state.id+'/embed'}
+            title={`instagram-embed-${this.state.id}`}
             frameBorder={0}
             allowFullScreen={true} />
         </div>
@@ -29,7 +30,7 @@ class Instagram extends BaseEmbed {
 
 Instagram.defaultProps = {
   url: '',
-  regex: /https?:\/\/(?:www\.){0,1}instagram\.com\/p\/([^\/]+)\/?.*/gi
+  regex: /https?:\/\/(?:www\.){0,1}instagram\.com\/p\/([^/]+)\/?.*/gi
 };
 
 export default Instagram;

--- a/src/blocks/embeds/vimeo.js
+++ b/src/blocks/embeds/vimeo.js
@@ -7,7 +7,7 @@ class Vimeo extends BaseEmbed {
       if(!this.state.preview) {
         return (
           <div className="katap-embed katap-vimeo">
-            <p>Vimeo - <a href={this.props.url} target="_blank">{this.props.url}</a></p>
+            <p>Vimeo - <a href={this.props.url} target="_blank" rel="noopener noreferrer">{this.props.url}</a></p>
             <button className="katap-show-preview-btn" onClick={this.showPreview}>Preview</button>
           </div>
         );
@@ -15,6 +15,7 @@ class Vimeo extends BaseEmbed {
       return (
         <div className="katap-embed katap-vimeo">
           <iframe
+            title={`vimeo-embed-${this.state.id}`}
             src={'//player.vimeo.com/video/'+this.state.id}
             frameBorder={0}
             width={580}
@@ -31,7 +32,7 @@ class Vimeo extends BaseEmbed {
 
 Vimeo.defaultProps = {
   url: '',
-  regex: /(?:http[s]?:\/\/)?(?:www.)?vimeo\.co(?:.+(?:\/)([^\/].*)+$)/
+  regex: /(?:http[s]?:\/\/)?(?:www.)?vimeo\.co(?:.+(?:\/)([^/].*)+$)/
 };
 
 export default Vimeo;

--- a/src/blocks/embeds/vine.js
+++ b/src/blocks/embeds/vine.js
@@ -25,7 +25,7 @@ class Vine extends BaseEmbed {
       if(!this.state.preview) {
         return (
           <div className="katap-embed katap-vine">
-            <p>Vine - <a href={this.props.url} target="_blank">{this.props.url}</a></p>
+            <p>Vine - <a href={this.props.url} target="_blank" rel="noopener noreferrer">{this.props.url}</a></p>
             <button className="katap-show-preview-btn" onClick={this.showPreview}>Preview</button>
           </div>
         );
@@ -35,6 +35,7 @@ class Vine extends BaseEmbed {
         <div className="katap-embed katap-vine">
           <iframe
             className="vine-embed"
+            title={`vine-embed-${this.state.id}`}
             src={'//vine.co/v/'+this.state.id+'/embed/postcard'}
             frameBorder={0}
             width={600}

--- a/src/blocks/embeds/youtube.js
+++ b/src/blocks/embeds/youtube.js
@@ -5,6 +5,9 @@ class Youtube extends BaseEmbed {
   constructor(props) {
     super(props);
 
+    this.start = null;
+    this.end = null;
+
     this.onChange = this.onChange.bind(this);
     this.renderInput = this.renderInput.bind(this);
   }
@@ -14,8 +17,8 @@ class Youtube extends BaseEmbed {
       e.preventDefault();
     }
     const meta = {}
-    meta.start = this.refs.start.value;
-    meta.end = this.refs.end.value;
+    meta.start = this.start.value;
+    meta.end = this.end.value;
 
     this.props.updateMeta(meta);
   }
@@ -25,8 +28,8 @@ class Youtube extends BaseEmbed {
     return (
       <div className="katap-embed-inp-container">
         <form onSubmit={this.onChange}>
-          <label>Start Time: <input type="text" ref="start" defaultValue={meta.start || ''} /></label>
-          <label>End Time: <input type="text" ref="end" defaultValue={meta.end || ''} /></label>
+          <label>Start Time: <input type="text" ref={(node) => {this.start=node}} defaultValue={meta.start || ''} /></label>
+          <label>End Time: <input type="text" ref={(node) => {this.end=node}} defaultValue={meta.end || ''} /></label>
           <button className="katap-show-preview-btn" onClick={this.onChange}>Update</button>
         </form>
       </div>
@@ -38,7 +41,7 @@ class Youtube extends BaseEmbed {
       if(!this.state.preview) {
         return (
           <div className="katap-embed katap-youtube">
-            <p>Youtube Video - <a href={this.props.url} target="_blank">{this.props.url}</a></p>
+            <p>Youtube Video - <a href={this.props.url} target="_blank" rel="noopener noreferrer">{this.props.url}</a></p>
             <button className="katap-show-preview-btn" onClick={this.showPreview}>Preview</button>
           </div>
         );
@@ -55,6 +58,7 @@ class Youtube extends BaseEmbed {
         <div className="katap-embed katap-youtube">
         <iframe
           src={url}
+          title={`youtube-embed-${this.state.id}`}
           frameBorder={0}
           width={580}
           height={320}
@@ -70,7 +74,7 @@ class Youtube extends BaseEmbed {
 
 Youtube.defaultProps = {
   url: '',
-  regex: /^.*(?:(?:youtu\.be\/)|(?:youtube\.com)\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*)/
+  regex: /^.*(?:(?:youtu\.be\/)|(?:youtube\.com)\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*)/
 };
 
 export default Youtube;

--- a/src/blocks/image.js
+++ b/src/blocks/image.js
@@ -9,6 +9,7 @@ class BlockImage extends React.Component {
 
   constructor(props) {
     super(props);
+    this.imgEl = null;
     this.handleImage = this.handleImage.bind(this);
     this.changeItem = this.changeItem.bind(this);
     this.handleKeyPress = this.handleKeyPress.bind(this);
@@ -18,7 +19,7 @@ class BlockImage extends React.Component {
   componentDidMount() {
     var content = this.props.content;
     if(!content || content.url === "") {
-      this.refs.img.focus();
+      this.imgEl.focus();
     }
   }
 
@@ -76,7 +77,7 @@ class BlockImage extends React.Component {
       {(!content || content.url === '') ? (
         <div>
           <input
-            ref="img"
+            ref={(node) => {this.imgEl=node}}
             type="text"
             placeholder="Paste URL of image and press enter"
             onKeyDown={this.handleKeyPress} />
@@ -87,7 +88,7 @@ class BlockImage extends React.Component {
         </div>
       ) : (
         <div>
-          <img src={content.url} onLoad={this.imageLoaded} />
+          <img src={content.url} onLoad={this.imageLoaded} alt="Not loaded"/>
           <input
             type="text"
             className="katap-image-subtext"

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -7,7 +7,7 @@ import Quote from './quote';
 import Text from './text';
 import UL from './ul';
 
-module.exports = {
+export default {
   text: Text,
   image: Image,
   embed: Embed,

--- a/src/blocks/ol.js
+++ b/src/blocks/ol.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import Action from '../utils/action';
 import LI from '../components/listitem';
 import BlockControl from '../components/blockcontrol';
 import {uuid} from '../utils';
@@ -67,6 +66,7 @@ class BlockOL extends React.Component {
             onContentChanged={self.onContentChanged} />
         </li>
       );
+      return null;
     });
     return li;
   }

--- a/src/blocks/quote.js
+++ b/src/blocks/quote.js
@@ -13,22 +13,22 @@ class BlockQuote extends BlockText.React {
   }
 
   onContentChanged(content) {
-    var content = {
+    var modContent = {
       content: content,
       credit: this.props.content.credit
     };
     if(this.props.onContentChanged) {
-      this.props.onContentChanged(this.props.position, content);
+      this.props.onContentChanged(this.props.position, modContent);
     }
   }
 
   onCreditChange(e) {
-    var content = {
+    var modContent = {
       content: this.props.content.content,
       credit: e.target.value
     };
     if(this.props.onContentChanged) {
-      this.props.onContentChanged(this.props.position, content);
+      this.props.onContentChanged(this.props.position, modContent);
     }
   }
 

--- a/src/components/droppable.js
+++ b/src/components/droppable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 class Droppable extends React.Component {
 
@@ -8,6 +7,10 @@ class Droppable extends React.Component {
     this.state = {
       className: ''
     };
+
+    this.fileEL = null;
+    this.droppable = null;
+
     this.getClassName = this.getClassName.bind(this);
     this.onDragEnter = this.onDragEnter.bind(this);
     this.onDragOver = this.onDragOver.bind(this);
@@ -29,7 +32,7 @@ class Droppable extends React.Component {
   }
 
   componentDidMount() {
-    this.refs.droppable.focus();
+    this.droppable.focus();
   }
 
   onDragOver(e) {
@@ -52,7 +55,7 @@ class Droppable extends React.Component {
   }
 
   onClick() {
-    var fileInput = this.refs.input;
+    var fileInput = this.fileEL;
     fileInput.value = null;
     fileInput.click();
   }
@@ -78,7 +81,7 @@ class Droppable extends React.Component {
   render() {
     return (
       <div
-        ref="droppable"
+        ref={(node) => {this.droppable=node}}
         style={{height: 100}}
         className={this.getClassName()}
         onDragEnter={this.onDragEnter}
@@ -87,7 +90,7 @@ class Droppable extends React.Component {
         onClick={this.onClick}
         onDrop={this.onDrop} >
         <input
-          ref="input"
+          ref={(node) => {this.fileEL=node}}
           type="file"
           style={{display: 'none'}}
           multiple={this.props.multiple}

--- a/src/components/scribe-options.js
+++ b/src/components/scribe-options.js
@@ -64,7 +64,7 @@ const normalizeLink = (link) => {
   if (link.indexOf('@') >= 0) {
     return 'mailto:' + link;
   }
-  if (link.indexOf('+') == 0) {
+  if (link.indexOf('+') === 0) {
     return 'tel:' + link;
   }
   return 'http://' + link;
@@ -103,7 +103,6 @@ export const linkCommand = function () {
 
     linkPromptCommand.getCurrentLink = function() {
       const selection = new scribe.api.Selection();
-      const range = selection.range;
       const anchorNode = selection.getContaining((node) => {
         return node.nodeName === this.nodeName;
       });

--- a/src/components/scribe.js
+++ b/src/components/scribe.js
@@ -35,6 +35,9 @@ export default class ScribeEditor extends React.Component {
     this.tempRange = null;
 
     this.scrollY = -1;
+    this.scribeeditor = null;
+    this.toolbar = null;
+    this.linkinput = null;
 
     this.placeCaretAtEnd = this.placeCaretAtEnd.bind(this);
     this.captureReturn = this.captureReturn.bind(this);
@@ -53,7 +56,7 @@ export default class ScribeEditor extends React.Component {
   }
 
   componentDidMount() {
-    this.dom = ReactDOM.findDOMNode(this.refs.scribeeditor);
+    this.dom = ReactDOM.findDOMNode(this.scribeeditor);
     this.scribe = new Scribe(this.dom);
     if (!this.props.inline) {
       this.scribe.use(pluginSmartLists());
@@ -118,7 +121,7 @@ export default class ScribeEditor extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState){
-    if (nextState.showToolbar !== this.state.showToolbar || nextState.showLinkInput !== this.state.showLinkInput || nextState.placeholder != this.state.placeholder) {
+    if (nextState.showToolbar !== this.state.showToolbar || nextState.showLinkInput !== this.state.showLinkInput || nextState.placeholder !== this.state.placeholder) {
       return true;
     }
     return false;
@@ -128,7 +131,7 @@ export default class ScribeEditor extends React.Component {
     if (!this.state.showToolbar) {
       return;
     }
-    const toolbar = this.refs.toolbar;
+    const toolbar = this.toolbar;
     const toolbarBoundary = toolbar.getBoundingClientRect();
     const selection = window.getSelection();
     const range = selection.getRangeAt(0);
@@ -172,7 +175,7 @@ export default class ScribeEditor extends React.Component {
     if (e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) {
       return;
     }
-    if(e.which == Keys.ENTER) {
+    if(e.which === Keys.ENTER) {
       if (this.props.inline || this.props.enterCapture) {
         e.preventDefault();
       }
@@ -268,9 +271,9 @@ export default class ScribeEditor extends React.Component {
         this.setState({ showLinkInput: true, showToolbar: true}, () => {
           this.tempRange = new this.scribe.api.Selection().range;
           setTimeout(() => {
-            this.refs.linkinput.focus();
-            this.refs.linkinput.select();
-            this.refs.linkinput.value = currentLink;
+            this.linkinput.current.focus();
+            this.linkinput.current.select();
+            this.linkinput.current.value = currentLink;
           }, 0);
         });
       }
@@ -290,9 +293,8 @@ export default class ScribeEditor extends React.Component {
     return (
       <div className="katap-scribe-container">
         { this.state.showToolbar ? (
-          <div className={'katap-scribe-toolbar' + (this.state.showLinkInput ? ' katap-link-inp-visible' : '')} ref="toolbar">
+          <div className={'katap-scribe-toolbar' + (this.state.showLinkInput ? ' katap-link-inp-visible' : '')} ref={(node) => {this.toolbar=node}}>
             { !this.state.showLinkInput ? toolbarButtons.map(btn => {
-              const _scribe = this.scribe;
               const className = 'katap-inline-toolbar-btn katap-inline-btn-' + btn.command;
               return (
                 <button className={className} key={btn.command} title={btn.command.toUpperCase()} onMouseDown={() => this.handleCommand(btn.command)}>
@@ -301,7 +303,7 @@ export default class ScribeEditor extends React.Component {
               );
             }) : (
               <input
-                ref="linkinput"
+                ref={(node) => {this.linkinput=node}}
                 type="text"
                 className="katap-scribe-link-input"
                 placeholder="Paste and ENTER"
@@ -311,7 +313,7 @@ export default class ScribeEditor extends React.Component {
           }
           </div>
         ) : null }
-        <div ref="scribeeditor"
+        <div ref={(node) => {this.scribeeditor=node}}
           className="katap-medium-editor markdown-body"
           onKeyUp={this.onSelect}
           onMouseUp={this.onSelect}

--- a/src/components/scribe.js
+++ b/src/components/scribe.js
@@ -271,9 +271,9 @@ export default class ScribeEditor extends React.Component {
         this.setState({ showLinkInput: true, showToolbar: true}, () => {
           this.tempRange = new this.scribe.api.Selection().range;
           setTimeout(() => {
-            this.linkinput.current.focus();
-            this.linkinput.current.select();
-            this.linkinput.current.value = currentLink;
+            this.linkinput.focus();
+            this.linkinput.select();
+            this.linkinput.value = currentLink;
           }, 0);
         });
       }

--- a/src/components/toolbar.js
+++ b/src/components/toolbar.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import Action from '../utils/action';
 import Blocks from '../blocks/';
 
 class Toolbar extends React.Component {
@@ -33,7 +32,6 @@ class Toolbar extends React.Component {
   }
 
   render() {
-    var self = this;
     var Blocks = this.props.availableBlocks;
     if(!this.state.visible) {
       return (

--- a/src/demo.js
+++ b/src/demo.js
@@ -70,7 +70,6 @@ class Container extends React.Component {
       <div>
         <button onClick={this.save}>console.log</button>
         <Editor
-          ref="kattappa"
           blocks={this.state.blocks}
           onChange={this.onChange}
           availableBlocks={Blocks}

--- a/src/editor.js
+++ b/src/editor.js
@@ -9,10 +9,6 @@ import EmbedTypes from './blocks/embeds';
 
 const splitterString = '<p>==</p>';
 
-var initialState = {
-  blocks: []
-};
-
 export default class Editor extends React.Component {
 
   constructor(props) {
@@ -36,7 +32,7 @@ export default class Editor extends React.Component {
       return;
     }
 
-    const splitterRegex = /((?:\<[a-zA-Z\d]{1,}\>){1,2}\<br\>(?:\<\/[a-zA-Z\d]{1,}\>){1,2})/gi;
+    const splitterRegex = /((?:<[a-zA-Z\d]{1,}>){1,2}<br>(?:<\/[a-zA-Z\d]{1,}>){1,2})/gi;
     const stringsFix = currentBlock.data.replace(splitterRegex, splitter);
     const stringsTmp = stringsFix.split(splitter);
 
@@ -65,7 +61,7 @@ export default class Editor extends React.Component {
     var newBlocks = this.props.blocks;
     var Blocks = this.props.availableBlocks;
     if(action === Action.REMOVE) {
-      if(Blocks[newBlocks[position].type].isEmpty(newBlocks[position].data) || confirm('Are you sure?')) {
+      if(Blocks[newBlocks[position].type].isEmpty(newBlocks[position].data) || window.confirm('Are you sure?')) {
         newBlocks.splice(position, 1);
       } else {
         return;
@@ -143,16 +139,16 @@ export default class Editor extends React.Component {
     }
     var rndr = blocks.map(function(block, index) {
 
-      var Block = Blocks[block.type].React;
       if(!Blocks[block.type]) {
         return null;
       }
+
+      var Block = Blocks[block.type].React;
 
       return (
         <div key={block.key} className="katap-container">
           {self.getToolbar(index)}
           <Block
-            ref={"block"+index}
             position={index}
             content={block.data}
             addBlock={self.addBlock}

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import BaseEmbed from './blocks/embeds/base';
 import ScribeComponent from './components/scribe';
 import DroppableComponent from './components/droppable';
 
-module.exports = {
+export default {
   Editor,
   Blocks,
   uuid,

--- a/src/utils/action.js
+++ b/src/utils/action.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   UP: "up",
   DOWN: "down",
   REMOVE: "remove"

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   uuid: function() {
     function s4() {
       return Math.floor((1 + Math.random()) * 0x10000)

--- a/src/utils/keys.js
+++ b/src/utils/keys.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   ENTER: 13,
   ESC: 27,
   BACKSPACE: 8,


### PR DESCRIPTION
Resolved some errors related to `string refs`

> string refs have some issues, are considered legacy, and are likely to be removed in one of the future releases

It could have been possible to use createRef which is recommended by the latest versions of React [Refs Doc](https://reactjs.org/docs/refs-and-the-dom.html). But since kattappa is running on 0.14, I had to have a work around to fix it.